### PR TITLE
Mark davison uws patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Yee-Light-Blue
+Yee-Light-Blue and Yee-Light-Blue-2 (Beta)
 ==============
+
+Yee Light Blue 2 is located inside the yeelightblue2 branch. Please checkout to yeelightblue2 or change inside the drop down list above to `yeelightblue2`. Be warn the code is still in beta development and still requires testing.
 
 Writing library for yee light blue using python for raspberry pi
 

--- a/yeelightblue.py
+++ b/yeelightblue.py
@@ -71,3 +71,14 @@ class YeeLightBlue:
     def delayOnStatusQuery(self):
         '''TODO: Function is missing UUID/Handle'''
         self.con.sendline('char-write-cmd 0x00__ RT')
+
+    def white(self,temperature,brightness):
+        a_str = "CLTMP " + temperature + ',' + brightness + ','
+        for letter in range(len(a_str),18):
+            #print letter
+            a_str += ','
+            #print a_str
+        self.str2hex(a_str)
+	print a_str
+        print self.hexStr
+        self.con.sendline('char-write-cmd 0x0012 ' + self.hexStr)


### PR DESCRIPTION
Added function for controlling white colour temperature and brightness of YeeLight Blue II bulb.
"CLTMP 6500,100,,,," is **much much** brighter than "255,255,255,100,,,".
Usage x.white(temperature,brightness)
Modeled on original code, arguments are strings.
temperature '1700' to '6500'
brightness '0' to '100'

Indentation ok in my version but in pull request looks wrong on line 82, hopefully that's obvious.